### PR TITLE
Handle invalid code points in Unicode conversion

### DIFF
--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -229,10 +229,18 @@ export function convertEmojisToUnicode(text: string): string {
 }
 
 export function convertUnicodeToEmojis(text: string): string {
-	regexPatterns.unicode.lastIndex = 0;
-	return text.replace(regexPatterns.unicode, (_, codePoint) => {
-		return String.fromCodePoint(parseInt(codePoint, 16));
-	});
+        regexPatterns.unicode.lastIndex = 0;
+        return text.replace(regexPatterns.unicode, (match, codePoint) => {
+                const parsed = parseInt(codePoint, 16);
+                if (Number.isFinite(parsed)) {
+                        try {
+                                return String.fromCodePoint(parsed);
+                        } catch {
+                                return match;
+                        }
+                }
+                return match;
+        });
 }
 
 export function convertEmojisToHtmlEntities(text: string): string {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -201,6 +201,7 @@ describe('Emoji Converter Extension', () => {
     });
     it('should not throw on invalid unicode or html entity', () => {
       expect(() => convertUnicodeToEmojis('\\u{ZZZZ}')).to.not.throw();
+      expect(convertUnicodeToEmojis('\\u{ZZZZ}')).to.equal('\\u{ZZZZ}');
       expect(() => convertHtmlEntitiesToEmojis('&#notanumber;')).to.not.throw();
     });
     it('should allow composeConversions with no functions', () => {


### PR DESCRIPTION
## Summary
- gracefully handle invalid Unicode code points in `convertUnicodeToEmojis`
- test that invalid Unicode input is ignored

## Testing
- `npm test` *(fails: Cannot find module 'vscode')*