### PR TITLE
Add format detection tests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -379,7 +379,7 @@ function convertToMarkdownInEditor(editor: vscode.TextEditor) {
  * @param targetFormat The desired output format
  * @returns The converted text
  */
-function smartConvert(text: string, targetFormat: TextFormat): string {
+export function smartConvert(text: string, targetFormat: TextFormat): string {
 	// First, detect the source format
 	const sourceFormat = detectTextFormat(text);
 	
@@ -489,7 +489,7 @@ function smartConvert(text: string, targetFormat: TextFormat): string {
 /**
  * Enum representing different text formats
  */
-enum TextFormat {
+export enum TextFormat {
 	Unicode,
 	Html,
 	Markdown,
@@ -502,7 +502,7 @@ enum TextFormat {
  * @param text The text to analyze
  * @returns The detected format or Mixed if multiple formats are found
  */
-function detectTextFormat(text: string): TextFormat {
+export function detectTextFormat(text: string): TextFormat {
 	// Optimize by using early returns for common cases
 	
 	// Reset all regex patterns to ensure consistent behavior

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -12,6 +12,7 @@ import {
   emojiToMarkdownMap,
   markdownToEmojiMap
 } from '../src/conversion';
+import { smartConvert, detectTextFormat, TextFormat } from '../src/extension';
 
 describe('Emoji Converter Extension', () => {
   describe('convertEmojisToUnicode', () => {
@@ -225,6 +226,31 @@ describe('Emoji Converter Extension', () => {
         const shortcode = markdown.replace(/:/g, '');
         expect(normalizeEmoji(markdownToEmojiMap.get(shortcode) || '')).to.equal(normalizeEmoji(emoji));
       }
+    });
+  });
+
+  describe('smartConvert and detectTextFormat', () => {
+    it('should convert between supported formats', () => {
+      const emoji = '😀';
+      const unicode = '\\u{1F600}';
+      const html = '&#128512;';
+      const markdown = ':grinning:';
+
+      expect(smartConvert(emoji, TextFormat.Unicode)).to.equal(unicode);
+      expect(smartConvert(emoji, TextFormat.Html)).to.equal(html);
+      expect(smartConvert(emoji, TextFormat.Markdown)).to.equal(markdown);
+
+      expect(smartConvert(unicode, TextFormat.Emoji)).to.equal(emoji);
+      expect(smartConvert(html, TextFormat.Emoji)).to.equal(emoji);
+      expect(smartConvert(markdown, TextFormat.Emoji)).to.equal(emoji);
+    });
+
+    it('should identify text formats correctly', () => {
+      expect(detectTextFormat('😀')).to.equal(TextFormat.Emoji);
+      expect(detectTextFormat('\\u{1F600}')).to.equal(TextFormat.Unicode);
+      expect(detectTextFormat('&#128512;')).to.equal(TextFormat.Html);
+      expect(detectTextFormat(':grinning:')).to.equal(TextFormat.Markdown);
+      expect(detectTextFormat('😀 :grinning:')).to.equal(TextFormat.Mixed);
     });
   });
 });


### PR DESCRIPTION
## Summary
- export `smartConvert`, `detectTextFormat`, and `TextFormat`
- test smartConvert conversions and detectTextFormat identification

## Testing
- `npm test` *(fails: Cannot find module 'vscode' during compile)*